### PR TITLE
Move transaction log into sign block

### DIFF
--- a/src/client/arweave-client.ts
+++ b/src/client/arweave-client.ts
@@ -32,10 +32,11 @@ export const upload = async (_data: string, _tags: tag[]) => {
     });
 
     LOGGER.info("-------Transaction-------");
-    LOGGER.info(`[Transaction log] transactionId=${transaction.id}, transaction=${JSON.stringify(transaction)}`);
 
     await arweave.transactions.sign(transaction, ARWEAVE_KEY)
         .then(async () => {
+            LOGGER.info(`[Transaction log] transactionId=${transaction.id}, transaction=${JSON.stringify(transaction)}`);
+            
             let uploader = await arweave.transactions.getUploader(transaction);
 
             LOGGER.info("-------Beginning to upload data to the weave-------");

--- a/test/testweave-client.ts
+++ b/test/testweave-client.ts
@@ -33,10 +33,11 @@ export const uploadToTestWeave = async (_data: string, _tags: tag[]) => {
     });
 
     LOGGER.info("-------Transaction-------");
-    LOGGER.info(transaction)
 
     await arweave.transactions.sign(transaction, (await testInstance).rootJWK)
         .then(async () => {
+            LOGGER.info(`[Transaction log] transactionId=${transaction.id}, transaction=${JSON.stringify(transaction)}`);
+            
             let uploader = await arweave.transactions.getUploader(transaction);
 
             LOGGER.info("-------Beginning to upload data to the test weave-------");

--- a/yarn.lock
+++ b/yarn.lock
@@ -383,7 +383,7 @@ articles@~0.2.1:
   resolved "https://registry.yarnpkg.com/articles/-/articles-0.2.2.tgz#cc6b429f8cfa811f41e7a08505abbb4e45503197"
   integrity sha512-S3Y4MPp+LD/l0HHm/4yrr6MoXhUkKT98ZdsV2tkTuBNywqUXEtvJT+NBO3KTSQEttc5EOwEJe2Xw8cZ9TI5Hrw==
 
-arweave@^1.10.11, arweave@^1.10.16:
+arweave@^1.10.11, arweave@^1.10.13, arweave@^1.10.16, arweave@^1.10.17:
   version "1.10.18"
   resolved "https://registry.yarnpkg.com/arweave/-/arweave-1.10.18.tgz#3042edd1afa52b7c3caeacf88271758232c7b866"
   integrity sha512-i3pKBkLtU1Jl9RtJ9A6zgz8QqF5FZy7YA+qGQ9i2Zug171p29FTDZhN+KlRcVBg8sEgd1DKyecCCYJZ3K6Jdfg==
@@ -391,17 +391,6 @@ arweave@^1.10.11, arweave@^1.10.16:
     arconnect "^0.2.8"
     asn1.js "^5.4.1"
     axios "^0.22.0"
-    base64-js "^1.3.1"
-    bignumber.js "^9.0.1"
-
-arweave@^1.10.13, arweave@^1.10.17:
-  version "1.10.17"
-  resolved "https://registry.yarnpkg.com/arweave/-/arweave-1.10.17.tgz#85c214e54449e423c3758ef0957de3ac53c7668b"
-  integrity sha512-0QJu61oCDfEvyA/K1u3GyW5BHk5vyFvOnK9dHbKryIKK49RtsTvpEvCHE0Z7lEXEbmxDDLQEYy2exPFdpbVzIA==
-  dependencies:
-    arconnect "^0.2.8"
-    asn1.js "^5.4.1"
-    axios "^0.21.1"
     base64-js "^1.3.1"
     bignumber.js "^9.0.1"
 
@@ -1342,7 +1331,12 @@ fn.name@1.x.x:
   resolved "https://registry.yarnpkg.com/fn.name/-/fn.name-1.1.0.tgz#26cad8017967aea8731bc42961d04a3d5988accc"
   integrity sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==
 
-follow-redirects@^1.14.0, follow-redirects@^1.14.4:
+follow-redirects@^1.14.0:
+  version "1.14.5"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.5.tgz#f09a5848981d3c772b5392309778523f8d85c381"
+  integrity sha512-wtphSXy7d4/OR+MvIFbCVBDzZ5520qV8XfPklSN5QtxuMUJZ+b0Wnst1e1lCDocfzuCkHqj8k0FpZqO+UIaKNA==
+
+follow-redirects@^1.14.4:
   version "1.14.4"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.4.tgz#838fdf48a8bbdd79e52ee51fb1c94e3ed98b9379"
   integrity sha512-zwGkiSXC1MUJG/qmeIFH2HBJx9u0V46QGUe3YR1fXG8bXQxq7fLj0RjLZQ5nubr9qNJUZrH+xUcwXEoXNpfS+g==


### PR DESCRIPTION
- Moving the transaction log statement into the sign block to ensure the transactionId is available to actually log

### What does it do?

Moving the transaction log statement into the sign block to ensure the transactionId is available to actually log

### Any helpful background information?

The transactionId was coming up as undefined in the log statements during uploads, this is a fix to address that

### Any new dependencies? Why were they added?

updating the arweave version